### PR TITLE
Upgrade to OpenFastTrace 4.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM eclipse-temurin:22-jre-alpine
 # alpine comes with sh only, by default
 RUN apk add --no-cache bash
 
-ARG OFT_CORE_VERSION=4.1.0
+ARG OFT_CORE_VERSION=4.2.0
 ARG OFT_ASCIIDOC_PLUGIN_VERSION=0.3.0
 
 ENV LIB_DIR=/opt/oft/lib


### PR DESCRIPTION
Updated the core library, the asciidoc plugin works with any OFT core
library having major version 4.

Addresses #13