### PR TITLE
[#15] Upgrade to OpenFastTrace 4.3.0

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Lint artifacts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - shell: bash
         run: |
           shellcheck "${GITHUB_WORKSPACE}"/*.sh

--- a/.github/workflows/requirements-tracing.yaml
+++ b/.github/workflows/requirements-tracing.yaml
@@ -15,7 +15,7 @@ jobs:
     env:
       REPORT_FILENAME: "requirements-tracing-report.html"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run OpenFastTrace
         id: run-oft
@@ -27,7 +27,7 @@ jobs:
 
       - name: Upload tracing report
         id: upload-report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tracing-report
           path: ${{ env.REPORT_FILENAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # [impl->req~run-oft-trace-command~1]
-FROM eclipse-temurin:22-jre-alpine
+FROM eclipse-temurin:25-jre-alpine
 # alpine comes with sh only, by default
 RUN apk add --no-cache bash
 
-ARG OFT_CORE_VERSION=4.2.0
-ARG OFT_ASCIIDOC_PLUGIN_VERSION=0.3.0
+ARG OFT_CORE_VERSION=4.3.0
+ARG OFT_ASCIIDOC_PLUGIN_VERSION=0.3.1
 
 ENV LIB_DIR=/opt/oft/lib
 


### PR DESCRIPTION
Updated the core library, the asciidoc plugin works with any OFT core library having major version 4.

Fixes #15